### PR TITLE
Adding basic ray to geometry module.

### DIFF
--- a/source/polyplex/math/geometry.d
+++ b/source/polyplex/math/geometry.d
@@ -1,0 +1,28 @@
+module polyplex.math.geometry;
+import polyplex.math.vector;
+
+alias Ray2D = RayT!float2;
+alias Ray = RayT!float3;
+/// A ray that supports two and three dimensions
+struct RayT(VT) if(is(VT==float2) || is(VT==float3)) {
+  public VT ori;
+  public VT dir;
+  immutable alias VectorType = VT;
+
+  /// Constructs a ray with an origin and direction
+  public this ( VT origin, VT direction ) pure nothrow {
+    ori = origin;
+    dir = direction;
+  }
+
+  /// Returns a ray with a normalized ray direction
+  RayT!VT Normalize ( ) pure nothrow {
+    return RayT!VT(ori, dir.Normalize);
+  }
+}
+
+unittest {
+  import std.traits;
+  assert(__traits(compiles, Ray(float3(0.5f), float3(0.2f, 0.7f, 0f).Normalize)));
+  assert(__traits(compiles, Ray(float3(0.5f), float3(0.2f, 0.7f, 0f)).Normalize));
+}

--- a/source/polyplex/math/package.d
+++ b/source/polyplex/math/package.d
@@ -2,4 +2,6 @@ module polyplex.math;
 public import polyplex.math.matrix;
 public import polyplex.math.rectangle;
 public import polyplex.math.vector;
+public import polyplex.math.quaternion;
+public import polyplex.math.geometry;
 public static import Mathf = polyplex.math.mathf;


### PR DESCRIPTION
Added a simple geometry module that only supports 2D and 3D rays. Also added public imports for geometry and quaternion in the math package.